### PR TITLE
Fix error of `uninitialized constant Fluent::Input (NameError)`

### DIFF
--- a/lib/fluent/plugin/in_sendgrid_event.rb
+++ b/lib/fluent/plugin/in_sendgrid_event.rb
@@ -1,4 +1,5 @@
 require 'webrick/https'
+require 'fluent/input'
 
 module Fluent
   class SendGridEventInput < Input


### PR DESCRIPTION
When I use fluentd and fluent-plugin-sendgrid-event, Error occurred. Write in below.
Cloud you review this PR or advices about errors?
I hope to reply from you ;).

- Version

fluentd 1.11
fluent-plugin-sendgrid-event 0.0.5

- Error

```
/ # fluentd
2020-10-30 09:21:39 +0000 [info]: parsing config file is succeeded path="/etc/fluent/fluent.conf"
2020-10-30 09:21:39 +0000 [info]: gem 'fluent-plugin-datadog' version '0.12.1'
2020-10-30 09:21:39 +0000 [info]: gem 'fluent-plugin-sendgrid-event' version '0.0.5'
2020-10-30 09:21:39 +0000 [info]: gem 'fluentd' version '1.9.1'
Traceback (most recent call last):
        22: from /usr/bin/fluentd:23:in `<main>'
        21: from /usr/bin/fluentd:23:in `load'
        20: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/bin/fluentd:8:in `<top (required)>'
        19: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        18: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        17: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/command/fluentd.rb:330:in `<top (required)>'
        16: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/supervisor.rb:541:in `run_supervisor'
        15: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/engine.rb:80:in `run_configure'
        14: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/engine.rb:105:in `configure'
        13: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/root_agent.rb:152:in `configure'
        12: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/root_agent.rb:152:in `each'
        11: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/root_agent.rb:158:in `block in configure'
        10: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/root_agent.rb:312:in `add_source'
         9: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/plugin.rb:105:in `new_input'
         8: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/plugin.rb:155:in `new_impl'
         7: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/registry.rb:44:in `lookup'
         6: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/registry.rb:99:in `search'
         5: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/registry.rb:99:in `each'
         4: from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.9.1/lib/fluent/registry.rb:102:in `block in search'
         3: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
         2: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
         1: from /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-sendgrid-event-0.0.5/lib/fluent/plugin/in_sendgrid_event.rb:3:in `<top (required)>'
/usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-sendgrid-event-0.0.5/lib/fluent/plugin/in_sendgrid_event.rb:4:in `<module:Fluent>': uninitialized constant Fluent::Input (NameError)
```